### PR TITLE
Uses inline shortcode in alerts for large texts

### DIFF
--- a/layouts/shortcodes/alert.html
+++ b/layouts/shortcodes/alert.html
@@ -1,4 +1,12 @@
 <div class="alert alert-warning d-flex" role="alert">
-  <div class="flex-shrink-1 alert-icon">{{ with .Get "icon" }}{{.}}{{ end }}</div>
-  <div class="w-100">{{ with .Get "text" }}{{ . | safeHTML }}{{ end }}</div>
+  <div class="flex-shrink-1 alert-icon">{{ with .Get "icon" }}{{.}} {{ end }}</div>
+  {{ with .Get "text"}}
+    <div class="w-100">{{ . }} </div>
+  {{ else }}
+    {{ with .Inner}}
+      <div class="w-100"> {{ . | markdownify}}</div>
+    {{ else }}
+      {{ errorf "No valid text variable or Inner content given"}}
+    {{ end }}
+  {{ end}}
 </div>


### PR DESCRIPTION
## 📦 Content

- Adds `.Inner` block for large text content

You can use this shortcode in several ways:

1. with named parameter

```
{{< alert icon="👉" text="foobar" />}}
```

2. with inline form

```
{{< alert icon="👉" >}}
fghfghfghghfg
{{< /alert >}}
```

> **🔥  Important** 
> - if you use the inline form with the `text` parameter, the parameter is dominant and will be used.
> - Always use the terminating `/` in shortcodes. Otherwise hugo will populate empty `.Inner` params which truncates the page in this case
> - See https://gohugo.io/templates/shortcode-templates/#inline-shortcodes